### PR TITLE
Fix traceback when clearing cookies

### DIFF
--- a/src/android/com/cordova/plugins/cookiemaster/CookieMaster.java
+++ b/src/android/com/cordova/plugins/cookiemaster/CookieMaster.java
@@ -223,11 +223,7 @@ public class CookieMaster extends CordovaPlugin {
                             CookieManager cookieManager = CookieManager.getInstance();
 
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-                                cookieManager.removeAllCookies(new ValueCallback<Boolean>() {
-                                    @Override
-                                    public void onReceiveValue(Boolean value) {
-                                    }
-                                });
+                                cookieManager.removeAllCookies(null);
 
                                 cookieManager.flush();
                             } else {


### PR DESCRIPTION
removeAllCookies was causing a traceback that led to the app crashing on Android 8. 

`2020-09-25 10:04:59.411 21100-21180/com.j5.app.v28 E/AndroidRuntime: FATAL EXCEPTION: pool-1-thread-2
    Process: com.j5.app.v28, PID: 21100
    java.lang.IllegalStateException: removeAllCookies must be called on a thread with a running Looper.
        at org.chromium.android_webview.AwCookieManager.b(PG:31)
        at uh.removeAllCookies(PG:40)
        at com.cordova.plugins.cookiemaster.CookieMaster$5.run(CookieMaster.java:226)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:764)`

Since a looper is only required if you pass in a callback (see https://developer.android.com/reference/android/webkit/CookieManager#removeAllCookies(android.webkit.ValueCallback%3Cjava.lang.Boolean%3E)) and the callback wasn't doing anything; I'm passing in `null` instead.