### PR TITLE
Fix clear cookies error

### DIFF
--- a/src/android/com/cordova/plugins/cookiemaster/CookieMaster.java
+++ b/src/android/com/cordova/plugins/cookiemaster/CookieMaster.java
@@ -225,24 +225,28 @@ public class CookieMaster extends CordovaPlugin {
             Handler handler = new Handler(looper);
             handler.post(new Runnable() {
                 public void run() {
-                    final CookieManager cookieManager = CookieManager.getInstance();
+                    try {
+                        final CookieManager cookieManager = CookieManager.getInstance();
 
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-                        cookieManager.removeAllCookies(new ValueCallback<Boolean>() {
-                            @Override
-                            public void onReceiveValue(Boolean value) {
-                                looper.quitSafely();
-                                cookieManager.flush();
-                                callbackContext.success();
-                            }
-                        });
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+                            cookieManager.removeAllCookies(new ValueCallback<Boolean>() {
+                                @Override
+                                public void onReceiveValue(Boolean value) {
+                                    looper.quitSafely();
+                                    cookieManager.flush();
+                                    callbackContext.success();
+                                }
+                            });
 
-                    } else {
-                        cookieManager.removeAllCookie();
-                        cookieManager.removeSessionCookie();
-                        callbackContext.success();
+                        } else {
+                            cookieManager.removeAllCookie();
+                            cookieManager.removeSessionCookie();
+                            callbackContext.success();
+                        }
+
+                    } catch (Exception e) {
+                        callbackContext.error("Error clearing cookies: " + e.getMessage());
                     }
-
                 }
             });
             return true;

--- a/src/android/com/cordova/plugins/cookiemaster/CookieMaster.java
+++ b/src/android/com/cordova/plugins/cookiemaster/CookieMaster.java
@@ -223,11 +223,7 @@ public class CookieMaster extends CordovaPlugin {
                             CookieManager cookieManager = CookieManager.getInstance();
 
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-                                cookieManager.removeAllCookies(new ValueCallback<Boolean>() {
-                                    @Override
-                                    public void onReceiveValue(Boolean value) {
-                                    }
-                                });
+                                cookieManager.removeAllCookies(null);
 
                                 cookieManager.flush();
                             } else {


### PR DESCRIPTION
There were 2 issues with the existing code.
1) On Android 8 the app was crashing due to a traceback 
`
2020-09-25 10:04:59.411 21100-21180/com.j5.app.v28 E/AndroidRuntime: FATAL EXCEPTION: pool-1-thread-2
    Process: com.j5.app.v28, PID: 21100
    java.lang.IllegalStateException: removeAllCookies must be called on a thread with a running Looper.
        at org.chromium.android_webview.AwCookieManager.b(PG:31)
        at uh.removeAllCookies(PG:40)
        at com.cordova.plugins.cookiemaster.CookieMaster$5.run(CookieMaster.java:226)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:764)
`
removeAllCookies was being run in a thread created by the cordova ExecutorService (which does not use Loopers for its threads.) I have fixed this by creating a separate thread with a Looper for removeAllCookies  to run on.

2) We weren't waiting for the cookies to be cleared before calling callbackContext.success(). To avoid any races I'm now ony calling this in the callback that is provided to removeAllCookies.