### PR TITLE
Add clearCookies implementation for WKWebView

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
     "type": "git",
     "url": "git+https://github.com/Cartegraph/cordova-cookie-master.git"
   },
-  "version": "1.4.1"
+  "version": "1.4.1-j5.3"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
            id="cordova-plugin-cartegraph-cookie-master"
-      version="1.4.1">
+      version="1.4.1-j5.3">
     <name>CookieMaster</name>
     <description>This plugin enables the management of cookies in WebViews on iOS and Android as those platforms restrict the use of "document.cookie".</description>
     <license>MIT</license>

--- a/src/ios/CDVCookieMaster.m
+++ b/src/ios/CDVCookieMaster.m
@@ -181,7 +181,7 @@
 
 - (void)clearCookies:(CDVInvokedUrlCommand*)command
 {
-    if ([self.webView isKindOfClass:[WKWebView class]) {
+    if ([self.webView isKindOfClass:[WKWebView class]]) {
         NSSet *dataTypes = [NSSet setWithObject: WKWebsiteDataTypeCookies];
         WKWebsiteDataStore *dataStore = [WKWebsiteDataStore defaultDataStore];
         [dataStore fetchDataRecordsOfTypes: dataTypes


### PR DESCRIPTION
As described here https://www.gitmemory.com/issue/Cartegraph/cordova-cookie-master/1/529538821, the clearCookies method was not implemented for WKWebView

I've adapted the implementation here https://stackoverflow.com/questions/31289838/how-to-delete-wkwebview-cookies; making some changes so that the callback is called once all of the cookies are deleted. It requests all records of type cookie and iterates over each record (there's one record per domain) and removes it asynchronously.

Verified fix by logging in with a user with DB auth; logging out and logging in with another user with OAuth and checking that the username on the top right was correct, as well as that the datastores use the correct names (the web inspector wasn't allowing me to inspect cookies on the main page)

